### PR TITLE
feat: add support to cnab500

### DIFF
--- a/gocnab.go
+++ b/gocnab.go
@@ -78,6 +78,25 @@ func Marshal400(vs ...interface{}) ([]byte, error) {
 	return marshal(400, vs...)
 }
 
+// Marshal500 returns the CNAB 500 encoding of vs. The accepted types are struct
+// and slice of struct, where only the exported struct fields with the tag
+// "cnab" are going to be used. Invalid cnab tag ranges will generate errors.
+//
+// The following struct field types are supported: string, bool, int, int8,
+// int16, int32, int64, uint, uint8, uint16, uint23, uint64, float32, float64,
+// gocnab.Marshaler and encoding.TextMarshaler. Where string are transformed to
+// uppercase and are left aligned in the CNAB space, booleans are represented as
+// 1 or 0, numbers are right aligned with zeros and float decimal separators are
+// removed.
+//
+// When only one parameter is given the generated CNAB line will only have break
+// line symbols if the input is a slice of struct. When using multiple
+// parameters the library determinate that you are trying to build the full CNAB
+// file, so it add the breaking lines and the final control symbol.
+func Marshal500(vs ...interface{}) ([]byte, error) {
+	return marshal(500, vs...)
+}
+
 func marshal(lineSize int, vs ...interface{}) ([]byte, error) {
 	var cnab []byte
 

--- a/gocnab_test.go
+++ b/gocnab_test.go
@@ -639,6 +639,327 @@ func TestMarshal400(t *testing.T) {
 	}
 }
 
+func TestMarshal500(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		description   string
+		vs            []interface{}
+		expected      []byte
+		expectedError error
+	}{
+		{
+			description: "it should create a CNAB500 correctly from a struct",
+			vs: []interface{}{
+				struct {
+					FieldA int         `cnab:"0,20"`
+					FieldB string      `cnab:"20,50"`
+					FieldC float64     `cnab:"50,60"`
+					FieldD uint        `cnab:"60,70"`
+					FieldE bool        `cnab:"70,71"`
+					FieldF bool        `cnab:"71,80"`
+					FieldG customType1 `cnab:"80,110"`
+					FieldH customType2 `cnab:"110,140"`
+					FieldI time.Time   // should ignore fields without CNAB tag
+					FieldJ string      `cnab:"499,500"`
+				}{
+					FieldA: 123,
+					FieldB: "This is a test with a long text to check if the strip is working well",
+					FieldC: 50.30,
+					FieldD: 445,
+					FieldE: true,
+					FieldF: false,
+					FieldG: customType1(func() ([]byte, error) {
+						return []byte("This is a custom type test 1"), nil
+					}),
+					FieldH: customType2(func() ([]byte, error) {
+						return []byte("This is a custom type test 2"), nil
+					}),
+					FieldJ: "T",
+				},
+			},
+			expected: []byte(fmt.Sprintf("%020d%-30s%10s%010d1000000000%-30s%-30s%260s%100s",
+				123, "THIS IS A TEST WITH A LONG TEX", strings.Replace(fmt.Sprintf("0%010.2f", 50.30), ".", "", -1), 445, "THIS IS A CUSTOM TYPE TEST 1", "THIS IS A CUSTOM TYPE TEST 2", "", "T")),
+		},
+		{
+			description: "it should create a CNAB400 correctly from a slice of structs",
+			vs: []interface{}{
+				[]struct {
+					FieldA int         `cnab:"0,20"`
+					FieldB string      `cnab:"20,50"`
+					FieldC float64     `cnab:"50,60"`
+					FieldD uint        `cnab:"60,70"`
+					FieldE bool        `cnab:"70,71"`
+					FieldF bool        `cnab:"71,80"`
+					FieldG customType1 `cnab:"80,110"`
+					FieldH customType2 `cnab:"110,140"`
+					FieldI time.Time   // should ignore fields without CNAB tag
+					FieldJ string      `cnab:"499,500"`
+				}{
+					{
+						FieldA: 123,
+						FieldB: "This is a test with a long text to check if the strip is working well",
+						FieldC: 50.30,
+						FieldD: 445,
+						FieldE: true,
+						FieldF: false,
+						FieldG: customType1(func() ([]byte, error) {
+							return []byte("This is a custom type test 1"), nil
+						}),
+						FieldH: customType2(func() ([]byte, error) {
+							return []byte("This is a custom type test 2"), nil
+						}),
+						FieldJ: "T",
+					},
+					{
+						FieldA: 321,
+						FieldB: "This is another test",
+						FieldC: 30.50,
+						FieldD: 644,
+						FieldE: false,
+						FieldF: true,
+						FieldG: customType1(func() ([]byte, error) {
+							return []byte("This is a custom type test 3"), nil
+						}),
+						FieldH: customType2(func() ([]byte, error) {
+							return []byte("This is a custom type test 4"), nil
+						}),
+						FieldJ: "U",
+					},
+				},
+			},
+			expected: []byte(fmt.Sprintf("%020d%-30s%10s%010d1000000000%-30s%-30s%260s%100s\r\n%020d%-30s%10s%010d0000000001%-30s%-30s%260s%100s",
+				123, "THIS IS A TEST WITH A LONG TEX", strings.Replace(fmt.Sprintf("0%010.2f", 50.30), ".", "", -1), 445, "THIS IS A CUSTOM TYPE TEST 1", "THIS IS A CUSTOM TYPE TEST 2", "", "T",
+				321, "THIS IS ANOTHER TEST", strings.Replace(fmt.Sprintf("0%010.2f", 30.50), ".", "", -1), 644, "THIS IS A CUSTOM TYPE TEST 3", "THIS IS A CUSTOM TYPE TEST 4", "", "U")),
+		},
+		{
+			description: "it should create a full CNAB500 correctly from multiple inputs",
+			vs: []interface{}{
+				struct {
+					FieldA int         `cnab:"0,20"`
+					FieldB string      `cnab:"20,50"`
+					FieldC float64     `cnab:"50,60"`
+					FieldD uint        `cnab:"60,70"`
+					FieldE bool        `cnab:"70,71"`
+					FieldF bool        `cnab:"71,80"`
+					FieldG customType1 `cnab:"80,110"`
+					FieldH customType2 `cnab:"110,140"`
+					FieldI time.Time   // should ignore fields without CNAB tag
+					FieldJ string      `cnab:"499,500"`
+				}{
+					FieldA: 111,
+					FieldB: "This is something",
+					FieldC: 77.70,
+					FieldD: 45,
+					FieldE: false,
+					FieldF: false,
+					FieldG: customType1(func() ([]byte, error) {
+						return []byte("Hello 1"), nil
+					}),
+					FieldH: customType2(func() ([]byte, error) {
+						return []byte("Hello 2"), nil
+					}),
+					FieldJ: "T",
+				},
+				[]struct {
+					FieldA int         `cnab:"0,20"`
+					FieldB string      `cnab:"20,50"`
+					FieldC float64     `cnab:"50,60"`
+					FieldD uint        `cnab:"60,70"`
+					FieldE bool        `cnab:"70,71"`
+					FieldF bool        `cnab:"71,80"`
+					FieldG customType1 `cnab:"80,110"`
+					FieldH customType2 `cnab:"110,140"`
+					FieldI time.Time   // should ignore fields without CNAB tag
+					FieldJ string      `cnab:"499,500"`
+				}{
+					{
+						FieldA: 123,
+						FieldB: "This is a test with a long text to check if the strip is working well",
+						FieldC: 50.30,
+						FieldD: 445,
+						FieldE: true,
+						FieldF: false,
+						FieldG: customType1(func() ([]byte, error) {
+							return []byte("This is a custom type test 1"), nil
+						}),
+						FieldH: customType2(func() ([]byte, error) {
+							return []byte("This is a custom type test 2"), nil
+						}),
+						FieldJ: "U",
+					},
+					{
+						FieldA: 321,
+						FieldB: "This is another test",
+						FieldC: 30.50,
+						FieldD: 644,
+						FieldE: false,
+						FieldF: true,
+						FieldG: customType1(func() ([]byte, error) {
+							return []byte("This is a custom type test 3"), nil
+						}),
+						FieldH: customType2(func() ([]byte, error) {
+							return []byte("This is a custom type test 4"), nil
+						}),
+						FieldJ: "V",
+					},
+				},
+			},
+			expected: []byte(fmt.Sprintf("%020d%-30s%10s%010d0000000000%-30s%-30s%260s%100s\r\n%020d%-30s%10s%010d1000000000%-30s%-30s%260s%100s\r\n%020d%-30s%10s%010d0000000001%-30s%-30s%260s%100s\x1a",
+				111, "THIS IS SOMETHING", strings.Replace(fmt.Sprintf("0%010.2f", 77.70), ".", "", -1), 45, "HELLO 1", "HELLO 2", "", "T",
+				123, "THIS IS A TEST WITH A LONG TEX", strings.Replace(fmt.Sprintf("0%010.2f", 50.30), ".", "", -1), 445, "THIS IS A CUSTOM TYPE TEST 1", "THIS IS A CUSTOM TYPE TEST 2", "", "U",
+				321, "THIS IS ANOTHER TEST", strings.Replace(fmt.Sprintf("0%010.2f", 30.50), ".", "", -1), 644, "THIS IS A CUSTOM TYPE TEST 3", "THIS IS A CUSTOM TYPE TEST 4", "", "V")),
+		},
+		{
+			description: "it should detect an invalid field format",
+			vs: []interface{}{
+				struct {
+					FieldA int `cnab:"xxxxxxxx"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagFormat,
+			},
+		},
+		{
+			description: "it should detect an invalid begin range",
+			vs: []interface{}{
+				[]struct {
+					FieldA int `cnab:"X,20"`
+				}{
+					{},
+				},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagBeginRange,
+			},
+		},
+		{
+			description: "it should detect an invalid end range",
+			vs: []interface{}{
+				struct {
+					FieldA int `cnab:"0,X"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagEndRange,
+			},
+		},
+		{
+			description: "it should detect an invalid range (negative begin)",
+			vs: []interface{}{
+				struct {
+					FieldA int `cnab:"-1,20"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagRange,
+			},
+		},
+		{
+			description: "it should detect an invalid range (end before begin)",
+			vs: []interface{}{
+				struct {
+					FieldA int `cnab:"20,0"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagRange,
+			},
+		},
+		{
+			description: "it should detect an invalid range (end after CNAB limit)",
+			vs: []interface{}{
+				struct {
+					FieldA int `cnab:"0,501"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldA",
+				Err:   gocnab.ErrInvalidFieldTagRange,
+			},
+		},
+		{
+			description: "it should detect an error in MarshalCNAB",
+			vs: []interface{}{
+				struct {
+					FieldG customType1 `cnab:"80,110"`
+				}{
+					FieldG: customType1(func() ([]byte, error) {
+						return nil, errors.New("generic problem")
+					}),
+				},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldG",
+				Err:   errors.New("generic problem"),
+			},
+		},
+		{
+			description: "it should detect an error in encoding.MarshalText",
+			vs: []interface{}{
+				struct {
+					FieldH customType2 `cnab:"110,140"`
+				}{
+					FieldH: customType2(func() ([]byte, error) {
+						return nil, errors.New("generic problem")
+					}),
+				},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldH",
+				Err:   errors.New("generic problem"),
+			},
+		},
+		{
+			description: "it should detect an unsupported field",
+			vs: []interface{}{
+				struct {
+					FieldJ struct{} `cnab:"140,150"`
+				}{},
+			},
+			expectedError: gocnab.FieldError{
+				Field: "FieldJ",
+				Err:   gocnab.ErrUnsupportedType,
+			},
+		},
+		{
+			description:   "it should detect an unsupported root type",
+			vs:            []interface{}{10},
+			expectedError: gocnab.ErrUnsupportedType,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			data, err := gocnab.Marshal500(scenario.vs...)
+
+			if !reflect.DeepEqual(scenario.expected, data) {
+				expectedStr := "<nil>"
+				if scenario.expected != nil {
+					expectedStr = string(scenario.expected)
+				}
+
+				dataStr := "<nil>"
+				if data != nil {
+					dataStr = string(data)
+				}
+
+				t.Errorf("expected data “%s” and got “%s”", expectedStr, dataStr)
+			}
+
+			if !reflect.DeepEqual(scenario.expectedError, err) {
+				t.Errorf("expected error “%v” and got “%v”", scenario.expectedError, err)
+			}
+		})
+	}
+}
+
 func TestUnmarshal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Hello,

This PR add support to CNAB500 used by 

```
SCC Sistema de Controle de Cessão
Troca Eletrônica
Padrão ATT – Cobrança
Retorno
VERSÃO 2.2
```

This [File _pastebin hosted_](https://pastebin.com/bhjvbQzD) was generated when execute this example:
```go
	header := struct {
		Identifier string `cnab:"0,1"`
		HeaderA    int    `cnab:"1,5"`
	}{
		HeaderA: 2,
	}

	content := []struct {
		Identifier string  `cnab:"0,1"`
		FieldA     int     `cnab:"1,20"`
		FieldB     string  `cnab:"20,50"`
		FieldC     float64 `cnab:"50,60"`
		FieldD     uint    `cnab:"60,70"`
		FieldE     bool    `cnab:"70,71"`
		FieldF     string  `cnab:"499,500"`
	}{
		{
			FieldA: 123,
			FieldB: "This is a text",
			FieldC: 50.30,
			FieldD: 445,
			FieldE: true,
			FieldF: "F",
		},
		{
			FieldA: 321,
			FieldB: "This is another text",
			FieldC: 30.50,
			FieldD: 544,
			FieldE: false,
			FieldF: "F",
		},
	}

	footer := struct {
		Identifier string `cnab:"0,1"`
		FooterA    string `cnab:"5,30"`
	}{
		FooterA: "Final text",
	}

	data, _ := gocnab.Marshal500(header, content, footer)

	fmt.Println(string(data))

```

let me know if  some improvements needed. :warning: 

Have a good one. :+1: 